### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "urls": [
+    ["bmp581mod.py", "github:octaprog7/bmp581/bmp581mod.py"],
+    ["sensor_pack/__init__.py", "github:octaprog7/bmp581/sensor_pack/__init__.py"],
+    ["sensor_pack/base_sensor.py", "github:octaprog7/bmp581/sensor_pack/base_sensor.py"],
+    ["sensor_pack/bus_service.py", "github:octaprog7/bmp581/sensor_pack/bus_service.py"],
+    ["sensor_pack/converter.py", "github:octaprog7/bmp581/sensor_pack/converter.py"],
+    ["sensor_pack/crc_mod.py", "github:octaprog7/bmp581/sensor_pack/crc_mod.py"],
+    ["sensor_pack/geosensmod.py", "github:octaprog7/bmp581/sensor_pack/geosensmod.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the BMP581 barometric pressure sensor driver module and its dependencies.